### PR TITLE
24. Mai 2025 - Hoppy Dice Tournament

### DIFF
--- a/config/_default/menus.de.yaml
+++ b/config/_default/menus.de.yaml
@@ -3,6 +3,10 @@ main:
     pre: <span data-feather='users'></span>
     url: /de/about/
     weight: 1
+  - name: Events
+    pre: <span data-feather='calendar'></span>
+    url: /de/events/
+    weight: 2
   - name: Starten mit Warhammer 40,000
     pre: <span data-feather='play'></span>
     url: /de/getting-started/

--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -3,6 +3,10 @@ main:
     pre: <span data-feather='users'></span>
     url: /en/about/
     weight: 1
+  - name: Events
+    pre: <span data-feather='calendar'></span>
+    url: /en/events/
+    weight: 2
   - name: Terrain Layouts
     pre: <span data-feather='map'></span>
     url: /en/terrain-layouts/

--- a/content/de/events.md
+++ b/content/de/events.md
@@ -24,7 +24,7 @@ Anmelden kannst du dich auf [Best Coast Pairings](https://www.bestcoastpairings.
 ## Details (v{{% param version %}})
 ### Regeln
 
-Gespielt wird nach dem [Pariah Nexus Tournament Companion](https://assets.warhammer-community.com/eng_warhammer40000_pariah_nexus_tournament_companion-eixdmbxjrp-dddcylhhbo.pdf).
+Gespielt wird nach dem [Pariah Nexus Tournament Companion](https://www.warhammer-community.com/en-gb/downloads/warhammer-40000/).
 
 **Listen** müssen bis spätestens am Samstag, **17.05.25 23:59 Uhr**, auf Best Coast Pairings hochgeladen sein.
 Zugelassen sind alle Einheiten, die im aktuellen [Munitorum Field Manual](https://www.warhammer-community.com/en-gb/downloads/warhammer-40000/) aufgeführt sind.

--- a/content/de/events.md
+++ b/content/de/events.md
@@ -4,11 +4,11 @@ type: page
 showTableOfContents: true
 version: "1.0"
 ---
-# 1. Februar 2025 - Hoppy Dice Tournament
+# 24. Mai 2025 - Hoppy Dice Tournament
 
-Wir führen unser erstes Warhammer 40,000-Turnier zusammen mit [diespieler.ch](https://diespieler.ch) durch!
+Wir führen unser nächstes Warhammer 40,000-Turnier zusammen mit [diespieler.ch](https://diespieler.ch) durch!
 
-- **Datum:** 1. Februar 2025, 9:00-20:00 Uhr
+- **Datum:** 24. Mai 2025, 9:00-20:00 Uhr
 - **Ort:** Seilerstrasse 4, 3011 Bern
 
 Die Platzzahl ist auf 8 beschränkt. Es werden 3 Runden mit 2000 Punkten und den neusten Matched Play-Regeln gespielt.
@@ -18,7 +18,7 @@ Zu gewinnen wird es nebst einem Pokal eine Combat Patrol-Box nach Wahl und weite
 
 ## Anmeldung
 
-Anmelden kannst du dich auf [Best Coast Pairings](https://www.bestcoastpairings.com/event/BY47T0PFL8).
+Anmelden kannst du dich auf [Best Coast Pairings](https://www.bestcoastpairings.com/event/4J87vPgoZIMJ).
 
 
 ## Details (v{{% param version %}})
@@ -26,23 +26,23 @@ Anmelden kannst du dich auf [Best Coast Pairings](https://www.bestcoastpairings.
 
 Gespielt wird nach dem [Pariah Nexus Tournament Companion](https://assets.warhammer-community.com/eng_warhammer40000_pariah_nexus_tournament_companion-eixdmbxjrp-dddcylhhbo.pdf).
 
-**Listen** müssen bis spätestens am Samstag, **25.1.25 23:59 Uhr**, auf Best Coast Pairings hochgeladen sein.
-Zugelassen sind alle Einheiten, die im aktuellen [Munitorum Field Manual](https://assets.warhammer-community.com/eng_wh40k_core&key_munitorum_field_manual_dec2024-7nrluyjjjp-ati25utyka.pdf) aufgeführt sind.
+**Listen** müssen bis spätestens am Samstag, **17.05.25 23:59 Uhr**, auf Best Coast Pairings hochgeladen sein.
+Zugelassen sind alle Einheiten, die im aktuellen [Munitorum Field Manual](https://www.warhammer-community.com/en-gb/downloads/warhammer-40000/) aufgeführt sind.
 
-**Stichtag** für Codexes, Balance Dataslates und weitere Erratas ist der **23.1.25**.
+**Stichtag** für Codexes, Balance Dataslates und weitere Erratas ist der **12.05.25**.
 
 
 ### Ablauf
 
-|        |                  |                                                             |                            |
-| ------ | ---------------- | ----------------------------------------------------------- | -------------------------- |
-| 08:30  | Türöffnung       |                                                             |                            |
-| 09:00  | Spiel 1          | Mission O (Terraform, Stalwarts, Crucible of Battle)        | Terrain&#160;Layout&#160;6 |
-| 12:00  | Mittagspause     |                                                             |                            |
-| 13:00  | Spiel 2          | Mission B (Purge the Foe, Smoke and Mirrors, Tipping Point) | Terrain&#160;Layout&#160;4 |
-| 16:00  | Pause            |                                                             |                            |
-| 16:30  | Spiel 3          | Mission S (Linchpin, Raise Banners, Dawn of War)            | Terrain&#160;Layout&#160;5 |
-| 19:45  | Rangverkündigung |                                                             |                            |
+|        |                  | 
+| ------ | ---------------- |
+| 08:30  | Türöffnung       |
+| 09:00  | Spiel 1          |
+| 12:00  | Mittagspause     |
+| 13:00  | Spiel 2          |
+| 16:00  | Pause            |
+| 16:30  | Spiel 3          |
+| 19:45  | Rangverkündigung |
 
 
 ### Terrain

--- a/content/en/events.md
+++ b/content/en/events.md
@@ -25,7 +25,7 @@ Please register on [Best Coast Pairings](https://www.bestcoastpairings.com/event
 ## Details (v{{% param version %}})
 ### Rules
 
-The game will be played according to the [Pariah Nexus Tournament Companion](https://assets.warhammer-community.com/eng_warhammer40000_pariah_nexus_tournament_companion-eixdmbxjrp-dddcylhhbo.pdf).
+The game will be played according to the [Pariah Nexus Tournament Companion](https://www.warhammer-community.com/en-gb/downloads/warhammer-40000/).
 
 **Lists** must be uploaded to Best Coast Pairings by Saturday, **May 17, 23:59** at the latest.
 All units listed in the current [Munitorum Field Manual](https://www.warhammer-community.com/en-gb/downloads/warhammer-40000/) are eligible.

--- a/content/en/events.md
+++ b/content/en/events.md
@@ -4,11 +4,11 @@ type: page
 showTableOfContents: true
 version: "1.0"
 ---
-## Feb 1, 2025 - Hoppy Dice Tournament
+## May 24, 2025 - Hoppy Dice Tournament
 
 We are running our first Warhammer 40,000 tournament together with [diespieler.ch](https://diespieler.ch)!
 
-- **Date:** February 1, 2025, 9:00-19:30
+- **Date:** May 24, 2025, 9:00-20:00
 - **Location:** Seilerstrasse 4, 3011 Bern
 
 This is an 8 player singles event over 3 rounds with 2000 points and the latest matched play rules.
@@ -19,7 +19,7 @@ In addition to a trophy, prizes include a Combat Patrol box of your choice and o
 ## Registration
 
 
-Please register on [Best Coast Pairings](https://www.bestcoastpairings.com/event/BY47T0PFL8).
+Please register on [Best Coast Pairings](https://www.bestcoastpairings.com/event/4J87vPgoZIMJ).
 
 
 ## Details (v{{% param version %}})
@@ -27,23 +27,23 @@ Please register on [Best Coast Pairings](https://www.bestcoastpairings.com/event
 
 The game will be played according to the [Pariah Nexus Tournament Companion](https://assets.warhammer-community.com/eng_warhammer40000_pariah_nexus_tournament_companion-eixdmbxjrp-dddcylhhbo.pdf).
 
-**Lists** must be uploaded to Best Coast Pairings by Saturday, **January 25, 23:59** at the latest.
-All units listed in the current [Munitorum Field Manual](https://assets.warhammer-community.com/eng_wh40k_core&key_munitorum_field_manual_dec2024-7nrluyjjjp-ati25utyka.pdf) are eligible.
+**Lists** must be uploaded to Best Coast Pairings by Saturday, **May 17, 23:59** at the latest.
+All units listed in the current [Munitorum Field Manual](https://www.warhammer-community.com/en-gb/downloads/warhammer-40000/) are eligible.
 
-**Deadline** for Codexes, Balance Dataslates and other Erratas is **January 23**.
+**Deadline** for Codexes, Balance Dataslates and other Erratas is **May 12**.
 
 
 ### Procedure
 
-|       |                      |                                                             |                            |
-| ----- | -------------------- | ----------------------------------------------------------- | -------------------------- |
-| 08:30 | Doors open           |                                                             |                            |
-| 09:00 | Game 1               | Mission O (Terraform, Stalwarts, Crucible of Battle)        | Terrain&#160;Layout&#160;6 |
-| 12:00 | Lunch break          |                                                             |                            |
-| 13:00 | Game 2               | Mission B (Purge the Foe, Smoke and Mirrors, Tipping Point) | Terrain&#160;Layout&#160;4 |
-| 16:00 | Break                |                                                             |                            |
-| 16:30 | Game 3               | Mission S (Linchpin, Raise Banners, Dawn of War)            | Terrain&#160;Layout&#160;5 |
-| 19:45 | Ranking announcement |                                                             |                            |
+|       |                      |
+| ----- | -------------------- |
+| 08:30 | Doors open           |
+| 09:00 | Game 1               |
+| 12:00 | Lunch break          |
+| 13:00 | Game 2               |
+| 16:00 | Break                |
+| 16:30 | Game 3               |
+| 19:45 | Ranking announcement |
 
 
 ### Terrain


### PR DESCRIPTION
- Turnierinformationen ohne Missionen/Layouts
- Link auf Munitorum Field Manual zeigt auf download weil sich dieser in den nächsten Tagen ändert